### PR TITLE
Release Binary for ARM64 architecture

### DIFF
--- a/scripts/build-all-platforms
+++ b/scripts/build-all-platforms
@@ -20,6 +20,11 @@ export GOARCH=arm
 export GOARM=7
 echo "Building for $GOOS/$GOARCH/$GOARM"
 go build -v -o build/jp-$GOOS-$GOARCH-arm$GOARM 2> /dev/null
+# Also build for ARM64/linux
+export GOOS=linux
+export GOARCH=arm64
+echo "Building for $GOOS/$GOARCH"
+go build -v -o build/jp-$GOOS-$GOARCH 2> /dev/null
 # And finally we'll create a .tar.gz version for homebrew users.
 cp build/jp-darwin-amd64 build/jp
 cd build


### PR DESCRIPTION
Hi

**Package Owner:** Prakriti Chauhan

**PR change Details:**

**$ Patch Details:** Following files has been modified:

- **scripts/build-all-platforms:** Added a new code to build the binary for arm64.

**$ Testing Detail:**
Followed the following steps to test the script on amd64 machine locally- 

- Install go 1.15 version

- Git clone jp package.

- Set the value of **JP_VERSION**

- Ran the command script **./scripts/build-all-platforms**

- It created the binary in the build folder and checked by running the architecture by running file command.

**Output:** 
```
root@7c5d67d9023e:/test/jp# file build/jp-linux-arm64
build/jp-linux-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=JAzIl8TyuFocOdVcxo57/4-rQu4i6TWziuPXiInPV/WLY2V31zbMzwS8OBz6oX/GZUTz8dn2k6AZ36I3H9N, not stripped
root@7c5d67d9023e:/test/jp#
```
**$ PR Description:** Here is my commit message :
Release binary for arm64 architecture

Here is my PR description -

The following files have been modified:

- In **scripts/build-all-platforms** file added a code to build the binary for arm64.

**$Reviewer:** Pruthvi Teja Reddy

Thanks
Prakriti Chauhan